### PR TITLE
Fixed prepending of new lines when table of contents was empty

### DIFF
--- a/lib/tocer/writer.rb
+++ b/lib/tocer/writer.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
+require "refinements/arrays"
 require "refinements/pathnames"
 
 module Tocer
   # Writes table of contents to a Markdown document.
   # :reek:DataClump
   class Writer
+    using Refinements::Arrays
     using Refinements::Pathnames
 
     def self.add start_index:, old_lines:, new_lines:
@@ -45,7 +47,7 @@ module Tocer
       ).join
     end
 
-    def prepend(lines, label) = content(lines, label) + "\n" + lines.join
+    def prepend(lines, label) = [content(lines, label), lines.join].compress.join("\n")
 
     def content(lines, label) = builder.call(lines, label: label)
   end

--- a/spec/lib/tocer/writer_spec.rb
+++ b/spec/lib/tocer/writer_spec.rb
@@ -166,5 +166,14 @@ RSpec.describe Tocer::Writer do
         BODY
       end
     end
+
+    context "when file has no headers" do
+      let(:fixture_path) { Bundler.root.join "spec/support/fixtures/basic.md" }
+
+      it "doesn't modify contents" do
+        writer.call test_path
+        expect(test_path.read).to eq("This is some *basic* Markdown.\n")
+      end
+    end
   end
 end

--- a/spec/support/fixtures/basic.md
+++ b/spec/support/fixtures/basic.md
@@ -1,0 +1,1 @@
+This is some *basic* Markdown.


### PR DESCRIPTION
## Overview

When attempting to build the Table of Contents for files which had no
headings at all, a new line was being prepended to these files. This
would cause these files to grow in size with a massive number of empty
lines. This fix ensures the contents of these files remain unchanged in
these situations.

## Details

- Resolves Issue #6.
